### PR TITLE
Replace `golang.org/x/exp/rand` with `math/rand/v2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/pebbe/zmq4 v1.2.11
 	github.com/rs/cors v1.11.0
 	github.com/rs/zerolog v1.33.0
-	golang.org/x/exp v0.0.0-20240716175740-e3f259677ff7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,6 @@ golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2Uz
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
-golang.org/x/exp v0.0.0-20240716175740-e3f259677ff7 h1:wDLEX9a7YQoKdKNQt88rtydkqDxeGaBUTnIYc3iG/mA=
-golang.org/x/exp v0.0.0-20240716175740-e3f259677ff7/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.19.0 h1:fEdghXQSo20giMthA7cd28ZC+jts4amQ3YMXiP5oMQ8=

--- a/kernel/utils.go
+++ b/kernel/utils.go
@@ -4,12 +4,11 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	mrand "math/rand/v2"
 	"net"
 	"os"
 	"runtime"
 	"strconv"
-
-	xrand "golang.org/x/exp/rand"
 
 	"github.com/rs/zerolog/log"
 )
@@ -54,7 +53,7 @@ func findAvailablePort() (int, error) {
 
 	// Start with a random port number or a specific range if needed.
 	for {
-		port := xrand.Intn(1000) + 5000
+		port := mrand.IntN(1000) + 5000
 		if portExists(port) {
 			continue
 		}


### PR DESCRIPTION
`math/rand/v2` is the replacement for `golang.org/x/exp/rand`:

> Once math/rand/v2 has shipped, we would tag and delete x/exp/rand.
> https://github.com/golang/go/issues/61716

1 less dependency.