### PR TITLE
Automate go binary release process using goreleaser

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,31 @@
+name: goreleaser
+
+on:
+  pull_request:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+  repository_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          distribution: goreleaser
-          version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@ before:
   hooks:
     - go mod tidy
     - npm --prefix ./ui i
-    - npm --prefix ./ui run build
+    - env CI=false npm --prefix ./ui run build
 
 builds:
   - id: zasper

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,38 @@
+project_name: zasper
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - npm --prefix ./ui i
+    - npm --prefix ./ui run build
+
+builds:
+  - id: zasper
+    env:
+      - CGO_ENABLED=0
+    main: .
+    targets:
+      - darwin_amd64
+      - darwin_arm64
+      - linux_386
+      - linux_amd64
+      - linux_arm64
+      - windows_386
+      - windows_amd64
+      - windows_arm64
+      - android_arm64
+
+archives:
+  - id: archive
+    builds:
+     - zasper
+    files:
+      - LICENSE
+    name_template: >-
+      {{ .ProjectName }}-{{- .Os }}-{{ .Arch }}
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip


### PR DESCRIPTION
This will trigger release of the go binary on new tags.

Example: https://github.com/btwiuse/zasper/releases 

Close #12 