### PR TITLE
Make Prettier skip linting carriage return for Windows

### DIFF
--- a/ui/.eslintrc.json
+++ b/ui/.eslintrc.json
@@ -13,7 +13,8 @@
         "singleQuote": true,
         "semi": true,
         "trailingComma": "es5",
-        "printWidth": 100
+        "printWidth": 100,
+        "endOfLine": "auto"
       }
     ],
     "react/prop-types": "off" ,


### PR DESCRIPTION
## Why

When you clone Zasper on Windows, depending on Git settings, a carraige return is added at the end of every line. With the current Prettier settings, `npm run build` fails due to a linting error.

## What

Make Prettier handle carriage return nicely so that it does not throw an error (mostly on Windows). See File Changes for more details.


