### PR TITLE
Improve stability of `GetJupyterPath()`

### DIFF
--- a/utils/paths.go
+++ b/utils/paths.go
@@ -68,27 +68,27 @@ func GetJupyterPath() []string {
 		fmt.Println(err)
 	}
 
-	// Get Python version (e.g., "3.9")
-	pythonVersion, err := getPythonVersion()
-	if err != nil {
-		return nil
-	}
-
+	
 	// Initialize an empty slice to hold the paths
 	paths := []string{}
-
+	
 	// Add various possible paths, using the home directory dynamically
 	paths = append(paths, filepath.Join(homeDir, ".local", "jupyter"))                                                                  // Linux
 	paths = append(paths, "/usr/local/share/jupyter")                                                                                   // Linux
 	paths = append(paths, filepath.Join(homeDir, ".local", "share", "jupyter"))                                                         // Linux
-	paths = append(paths, filepath.Join(homeDir, "Library", "Python", pythonVersion, "share", "jupyter"))                               // macOS
 	paths = append(paths, filepath.Join(homeDir, "Library", "Jupyter"))                                                                 // miniconda
 	paths = append(paths, filepath.Join(homeDir, "anaconda3", "share", "jupyter"))                                                      // Anaconda
 	paths = append(paths, filepath.Join(homeDir, "AppData", "Roaming", "jupyter"))                                                      // Windows
-	paths = append(paths, filepath.Join(homeDir, "AppData", "Local", "Programs", "Python", "Python"+pythonVersion, "share", "jupyter")) // Windows
 	paths = append(paths, filepath.Join(homeDir, "AppData", "Local", "Continuum", "anaconda3", "share", "jupyter"))                     // Windows
 	paths = append(paths, filepath.Join(homeDir, "AppData", "Local", "Enthought", "Canopy", "edm", "envs", "User", "share", "jupyter")) // Windows
-
+	
+	// Get Python version (e.g., "3.9")
+	pythonVersion, err := getPythonVersion()
+	if err != nil {
+		return paths
+	}
+	paths = append(paths, filepath.Join(homeDir, "Library", "Python", pythonVersion, "share", "jupyter"))                               // macOS
+	paths = append(paths, filepath.Join(homeDir, "AppData", "Local", "Programs", "Python", "Python"+pythonVersion, "share", "jupyter")) // Windows
 	paths = append(paths, filepath.Join(homeDir, "AppData", "Local", "Programs", "Python", "Python"+pythonVersion, "Lib", "site-packages", "notebook", "static")) // Windows
 
 	// Return the list of paths

--- a/utils/paths.go
+++ b/utils/paths.go
@@ -63,10 +63,9 @@ func getPythonVersion() (string, error) {
 
 // GetJupyterPath returns a list of possible Jupyter paths, making the function user-agnostic
 func GetJupyterPath() []string {
-	// Get the home directory from the environment variable
-	homeDir := os.Getenv("HOME")
-	if homeDir == "" {
-		fmt.Println("HOME environment variable is not set")
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Println(err)
 	}
 
 	// Get Python version (e.g., "3.9")


### PR DESCRIPTION
## Why

1. In some cases, an environment variable `HOME` may not be set and this may lead to incorrect build of `paths` inside `GetJupyterPath()`
2. If `getPythonVersion()` fails, the function returns an empty `paths` and it leads to 'No kernels available' on the frontend side.

## What

1. Use more robust and go built-in getter for user home directory. See File Changes for more details.
2. Move a code calling `getPythonVersion()` and codes depending on it to the end of the function so that 'hard-coded' paths are appended first.
