### PR TITLE
Use Go builtin OS temp dir

### DIFF
--- a/internal/kernel/kernel_supervisor.go
+++ b/internal/kernel/kernel_supervisor.go
@@ -121,7 +121,7 @@ func CwdForPath(path string) string {
 }
 
 func createKernelManager(kernelName string, kernelId string) (KernelManager, string, string) {
-	connectionDir := "/tmp/"
+	connectionDir := os.TempDir()
 	connectionFile := filepath.Join(connectionDir, "kernel-"+kernelId[:6]+".json")
 	km := KernelManager{
 		ConnectionFile: filepath.Join(connectionFile),


### PR DESCRIPTION
## Why

On Windows, `/tmp/` is an invalid path and it may lead to kernel creation fail.

## What

Use `os.TempDir()` instead of `/tmp/`
