### PR TITLE
Feat: Running Zasper remotely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ zasper_go
 examples
 ui/public/zasper
 kernelConnection.json
+
+# Caddy logs
+logs/

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,85 @@
+# Caddyfile for Zasper IDE
+# This configuration sets up a reverse proxy for the Zasper application
+
+# Replace 'your-domain.com' with your actual domain name
+# For local testing, you can use 'localhost' or remove the domain entirely
+zasper.ghcat.tech {
+	# Enable automatic HTTPS with Let's Encrypt
+	# Caddy will automatically obtain and renew SSL certificates
+
+	# Reverse proxy to the Zasper application
+	reverse_proxy localhost:8048 {
+		# Forward the real client IP
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-For {remote_host}
+		header_up X-Forwarded-Proto {scheme}
+
+		# WebSocket support for Jupyter kernels and terminal
+		# Zasper uses WebSockets extensively for kernel communication
+		# This ensures WebSocket connections are properly upgraded
+		@websockets {
+			header Connection *Upgrade*
+			header Upgrade websocket
+		}
+	}
+
+	# Enable compression for better performance
+	encode gzip zstd
+
+	# Security headers
+	header {
+		# Prevent clickjacking
+		X-Frame-Options SAMEORIGIN
+
+		# Prevent MIME type sniffing
+		X-Content-Type-Options nosniff
+
+		# Enable XSS protection
+		X-XSS-Protection "1; mode=block"
+
+		# Referrer policy
+		Referrer-Policy "strict-origin-when-cross-origin"
+	}
+
+	# Logging (using relative path to avoid permission issues)
+	log {
+		output file ./logs/zasper-access.log
+		format json
+	}
+}
+
+# Alternative configuration for local development or IP-based access
+# Uncomment and modify as needed
+# :8080 {
+#     reverse_proxy localhost:8048 {
+#         header_up X-Real-IP {remote_host}
+#         header_up X-Forwarded-For {remote_host}
+#         header_up X-Forwarded-Proto {scheme}
+#     }
+
+#     encode gzip zstd
+# }
+
+# Configuration for subdomain or path-based routing
+# Example: zasper.your-domain.com
+# zasper.your-domain.com {
+#     reverse_proxy localhost:8048 {
+#         header_up X-Real-IP {remote_host}
+#         header_up X-Forwarded-For {remote_host}
+#         header_up X-Forwarded-Proto {scheme}
+#     }
+#     
+#     encode gzip zstd
+# }
+
+# Configuration for path-based routing
+# Example: example.com/zasper
+# your-domain.com {
+#     handle /zasper* {
+#         reverse_proxy localhost:8048 {
+#             header_up X-Real-IP {remote_host}
+#             header_up X-Forwarded-For {remote_host}
+#             header_up X-Forwarded-Proto {scheme}
+#         }
+#     }
+# }

--- a/app.go
+++ b/app.go
@@ -68,6 +68,7 @@ func main() {
 	cwd := flag.String("cwd", ".", "base directory of project")
 	port := flag.String("port", ":8048", "port to start the server on")
 	protected := flag.Bool("protected", false, "enable protected mode")
+	host :=  flag.String("host", "127.0.0.1" ,  "host to start the server on") 
 
 	flag.Parse()
 
@@ -180,10 +181,10 @@ func main() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
-	printBanner(*port, core.ServerAccessToken, version, *protected)
+	printBanner(*port, core.ServerAccessToken, version, *protected, *host)
 
 	go func() {
-		if err := http.ListenAndServe(*port, corsOpts.Handler(router)); err != nil && err != http.ErrServerClosed {
+		if err := http.ListenAndServe( *host + *port, corsOpts.Handler(router)); err != nil && err != http.ErrServerClosed {
 			fmt.Printf("ListenAndServe(): %s\n", err)
 		}
 	}()
@@ -208,7 +209,7 @@ func main() {
 	fmt.Println("Server exiting")
 }
 
-func printBanner(port string, accessToken string, version string, protected bool) {
+func printBanner(port string, accessToken string, version string, protected bool, host string) {
 	fmt.Println("==========================================================")
 	fmt.Println("     ███████╗ █████╗ ███████╗██████╗ ███████╗██████╗ ")
 	fmt.Println("     ╚══███╔╝██╔══██╗██╔════╝██╔══██╗██╔════╝██╔══██╗")
@@ -221,8 +222,8 @@ func printBanner(port string, accessToken string, version string, protected bool
 	fmt.Printf("                Version: %s\n", version)
 	fmt.Println("----------------------------------------------------------")
 	fmt.Println(" ✅ Server started successfully!")
-	fmt.Printf(" 📡 Listening on:        http://localhost%s\n", port)
-	fmt.Printf(" 🖥️  Webapp available at: http://localhost%s\n", port)
+	fmt.Printf(" 📡 Listening on:        http://%s%s\n", host, port)
+	fmt.Printf(" 🖥️  Webapp available at: http://%s%s\n", host, port)
 	if protected {
 		fmt.Println(" 🔒 Protected Mode:      enabled")
 		fmt.Printf(" 🔐 Server Access Token: %s\n", accessToken)

--- a/app.go
+++ b/app.go
@@ -222,8 +222,8 @@ func printBanner(port string, accessToken string, version string, protected bool
 	fmt.Printf("                Version: %s\n", version)
 	fmt.Println("----------------------------------------------------------")
 	fmt.Println(" ✅ Server started successfully!")
-	fmt.Printf(" 📡 Listening on:        http://%s%s\n", host, port)
-	fmt.Printf(" 🖥️  Webapp available at: http://%s%s\n", host, port)
+	fmt.Printf(" 📡 Listening on:        http://%s:%s\n", host, port)
+	fmt.Printf(" 🖥️  Webapp available at: http://%s:%s\n", host, port)
 	if protected {
 		fmt.Println(" 🔒 Protected Mode:      enabled")
 		fmt.Printf(" 🔐 Server Access Token: %s\n", accessToken)


### PR DESCRIPTION
fix: https://github.com/zasper-io/zasper/issues/82

Todo : 

- [x] Add host flag in `app.go` for explicit http server address binding 
- [ ] Add  sample Caddy/Nginx/Apache server configuration for production deployment
- [ ] Add Docs for Caddy/Nginx/Apache server configuration usage